### PR TITLE
Fix: use delayed write flash page in AvrIspProtocol

### DIFF
--- a/pyedbglib/protocols/avrispprotocol.py
+++ b/pyedbglib/protocols/avrispprotocol.py
@@ -264,7 +264,7 @@ class AvrIspProtocol(Jtagice3Protocol):
         command.extend(data)
         self._spi_cmd_resp(command)
 
-    def write_flash_page(self, byte_address, data):
+    def write_flash_page(self, byte_address, data, delay_ms = 5):
         """
         Writes a page of flash
 
@@ -277,8 +277,8 @@ class AvrIspProtocol(Jtagice3Protocol):
             self.load_address(byte_address >> 1)
         command = bytearray([AvrIspProtocol.SPI_CMD_PROGRAM_FLASH])
         command.extend(binary.pack_be16(len(data)))
-        command.extend([0x81])  # Page mode
-        command.extend([0])  # Not used
+        command.extend([0x91])  # Write page with timed delay
+        command.extend([delay_ms])
         command.extend([AvrIspProtocol.AVR_LOAD_PAGE_COMMAND])
         command.extend([AvrIspProtocol.AVR_WRITE_PAGE_COMMAND])
         command.extend([0])  # Not used


### PR DESCRIPTION
This MR is about fixing the AvrIspProtocol.write_flash_page() by using the delayed write command with an optional delay parameter. A delayed write page flash is prefered over normal write command in terms of being in sync with MCU's flash memory timing constraints. 
See this issue  for further details :  https://github.com/microchip-pic-avr-tools/pymcuprog/issues/44

ref: https://smade.atlassian.net/browse/LC03T-477